### PR TITLE
Removing spacing:single

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: r
-cache: packages
+#cache: packages
 r_packages:
 - covr
 - drat

--- a/inst/extdata/monthly_report_luft.Rmd
+++ b/inst/extdata/monthly_report_luft.Rmd
@@ -6,7 +6,7 @@ header: "Sist oppdatert: `r format(Sys.time(), '%d.%m.%Y')`"
 #footer: "Sykdomspulsen fra Folkehelseinsttutet \\newline AAA \\newline A \\newline A "
 output: fhi::sykdompuls_luft_document
 fig_caption: true
-spacing: single
+#spacing: single
 ---
 
 # Luftveisinfeksjoner, `r f` {-}

--- a/inst/extdata/monthly_report_mage.Rmd
+++ b/inst/extdata/monthly_report_mage.Rmd
@@ -6,7 +6,7 @@ header: "Sist oppdatert: `r format(Sys.time(), '%d.%m.%Y')`"
 #footer: "Sykdomspulsen fra Folkehelseinsttutet \\newline AAA \\newline A \\newline A "
 output: fhi::sykdompuls_mage_document
 fig_caption: true
-spacing: single
+#spacing: single
 ---
 
 # Mage-tarminfeksjoner, `r f` {-}


### PR DESCRIPTION
In Jenkins (integration testing) we get the error:

```
! LaTex Error: Environment singlespacing undefined
```

I hope that by removing the YAML code: spacing:single that this problem will be fixed
